### PR TITLE
#39 Provisionally preventing duplicated chaindb folder by correlating…

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -17,9 +17,12 @@ import (
 
 var (
 	DataDirPath = "database"
+	
+	// IMPORTANT: Following three values needs to correspond to the internal values used by go-ethereum
 	KeystorePath = "keystore"
-	ChainDbPath = "chaindb"
+	ChainDbPath = "chaindata" // it needs to match to the value passed at go-ethereum/eth/backend.go:CreateDB()
 	GenesisPath = "genesis.json"
+	
 	blankGenesis = new(ethCore.Genesis)
 	errBlankGenesis = errors.New("could not parse a valid/non-blank Genesis")
 )
@@ -52,6 +55,10 @@ func NewConfig(dataDir string, ctx *cli.Context) (Config, error) {
 	gethCfg.NodeCfg.P2P.NoDiscovery = true
 	gethCfg.NodeCfg.DataDir = dataDir
 	
+	// IMPORTANT: If we do not define ".Name" Ethereum lib will automatically set it by the process name which will use 
+	// to generate every subfolder underneath
+	gethCfg.NodeCfg.Name = "."
+
 	// REMINDER: Following initialization is required to complete the configuration of the ethereum db
 	ethereum, err := ethNode.New(&gethCfg.NodeCfg)
 	if err != nil {

--- a/database/node.go
+++ b/database/node.go
@@ -36,7 +36,6 @@ func NewNode(cfg *Config, uriClient *rpcClient.URIClient) (*Node, error) {
 	}
 
 	ethereum, err := ethNode.New(&cfg.GethConfig.NodeCfg)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
… names

## Applied changes
- Rename `ChaindbPath` to match the name used internally by go-ethereum library
- Set as Node.Name `.` to prevent go-ethereum to use the process name as node name and nest every new node file/folder under a new created folder with the same name

## How to test
- Launch a new node and check chaindb path is correctly generated 

### IMPORTANT
- This is a breaking change as soon as this code is deployed it will detach the local ethereum db. We could manuall stop lighthchain and delete the old chaindb and let it synchronize again from tendermint wal file
- There might be a better solution such a bind a new ServiceContext method to `CreateDb()`