### PR TITLE
#141 Implementing support for --wsapi and --wsorigins

### DIFF
--- a/cmd/lightchain/ethereum_cli_ctx.go
+++ b/cmd/lightchain/ethereum_cli_ctx.go
@@ -16,8 +16,10 @@ var (
 	WSEnabledFlag = ethUtils.WSEnabledFlag
 	WSListenAddrFlag = ethUtils.WSListenAddrFlag
 	WSPortFlag = ethUtils.WSPortFlag
+	WSApiFlag = ethUtils.WSApiFlag
 	RPCCORSDomainFlag = ethUtils.RPCCORSDomainFlag
 	RPCVirtualHostsFlag = ethUtils.RPCVirtualHostsFlag
+	WSAllowedOriginsFlag = ethUtils.WSAllowedOriginsFlag
 )
 
 func addEthNodeFlags(cmd *cobra.Command) {
@@ -33,6 +35,8 @@ func addEthNodeFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(WSEnabledFlag.GetName(), false, WSEnabledFlag.Usage)
 	cmd.Flags().String(WSListenAddrFlag.GetName(), WSListenAddrFlag.Value, WSListenAddrFlag.Usage)
 	cmd.Flags().Int(WSPortFlag.GetName(), WSPortFlag.Value, WSPortFlag.Usage)
+	cmd.Flags().String(WSApiFlag.GetName(), WSApiFlag.Value, WSApiFlag.Usage)
+	cmd.Flags().String(WSAllowedOriginsFlag.GetName(), WSAllowedOriginsFlag.Usage, WSAllowedOriginsFlag.Usage)
 }
 
 func newNodeClientCtx(dataDir string, cmd *cobra.Command) *cli.Context {
@@ -70,6 +74,10 @@ func newNodeClientCtx(dataDir string, cmd *cobra.Command) *cli.Context {
 	flagSet.Int(WSPortFlag.GetName(), wsPortFlagValue, WSPortFlag.Usage)
 	flagSet.Set(WSPortFlag.GetName(), strconv.Itoa(wsPortFlagValue))
 	
+	wsApiFlagValue, _ := cmd.Flags().GetString(WSApiFlag.GetName())
+	flagSet.String(WSApiFlag.GetName(), wsApiFlagValue, WSApiFlag.Usage)
+	flagSet.Set(WSApiFlag.GetName(), wsApiFlagValue)
+	
 	rpcCORSDomainFlagValue, _ := cmd.Flags().GetString(RPCCORSDomainFlag.GetName())
 	flagSet.String(RPCCORSDomainFlag.GetName(), rpcCORSDomainFlagValue, RPCCORSDomainFlag.Usage)
 	flagSet.Set(RPCCORSDomainFlag.GetName(), rpcCORSDomainFlagValue)
@@ -77,6 +85,10 @@ func newNodeClientCtx(dataDir string, cmd *cobra.Command) *cli.Context {
 	rpcVirtualHostsFlagValue, _ := cmd.Flags().GetString(RPCVirtualHostsFlag.GetName())
 	flagSet.String(RPCVirtualHostsFlag.GetName(), rpcVirtualHostsFlagValue, RPCVirtualHostsFlag.Usage)
 	flagSet.Set(RPCVirtualHostsFlag.GetName(), rpcVirtualHostsFlagValue)
+	
+	wsAllowedOriginsFlagValue, _ := cmd.Flags().GetString(WSAllowedOriginsFlag.GetName())
+	flagSet.String(WSAllowedOriginsFlag.GetName(), wsAllowedOriginsFlagValue, WSAllowedOriginsFlag.Usage)
+	flagSet.Set(WSAllowedOriginsFlag.GetName(), wsAllowedOriginsFlagValue)
 
 	// Default values required
 	flagSet.String(ethUtils.GCModeFlag.GetName(), ethUtils.GCModeFlag.Value, ethUtils.GCModeFlag.Usage)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -40,7 +40,8 @@ DATA_DIR="${DATA_DIR}/${NETWORK}"
 INIT_ARGS="--datadir=${DATA_DIR} --${NETWORK}"
 
 RUN_ARGS="--datadir=${DATA_DIR}"
-RUN_ARGS="${RUN_ARGS} --rpc --rpcaddr=0.0.0.0 --rpcport=8545 --rpcapi eth,net,web3,personal,admin"
+RUN_ARGS="${RUN_ARGS} --rpc --rpcaddr 0.0.0.0 --rpcport 8545 --rpcapi eth,net,web3,personal,admin,debug --rpc"
+RUN_ARGS="${RUN_ARGS} --ws --wsport 8556 --wsaddr 0.0.0.0 --wsapi eth,net,web3,personal,admin,debug --wsorigins=*"
 RUN_ARGS="${RUN_ARGS} --tmt_rpc_port=26657 --tmt_proxy_port=26658 --tmt_p2p_port=26656"
 RUN_ARGS="${RUN_ARGS} --prometheus"
 


### PR DESCRIPTION
### Changes
- Adding support for --wsapi  flag
- Adding support for --wsorigins flag

### How to test
- Run a node using added flags: `lightchain run --wsapi=eth,web3,net,debug,personal,shh --ws --wsport=8556 --wsaddr=*`
- Run the following script to validate web3 api
```
const Web3 = require('web3');
let web3 = new Web3(new Web3.providers.WebsocketProvider("ws://localhost:8556"));
web3.eth.getAccounts()
    .then(console.log)
    .then(() => process.exit())
    .catch(console.error);
```
- It should print local created accounts