### PR TITLE
#110 Migrates Tendermint ABCI communication from socket to local client.

### DIFF
--- a/cmd/lightchain/init.go
+++ b/cmd/lightchain/init.go
@@ -129,8 +129,7 @@ func newNodeCfgFromCmd(cmd *cobra.Command) (node.Config, network.Network, error)
 		filepath.Join(dataDir, consensus.DataDirName),
 		TendermintRpcListenPort,
 		TendermintProxyListenPort,
-		TendermintP2PListenPort,
-		TendermintProxyProtocol,
+		TendermintProxyAppName,
 		false,
 	)
 

--- a/cmd/lightchain/init.go
+++ b/cmd/lightchain/init.go
@@ -128,7 +128,7 @@ func newNodeCfgFromCmd(cmd *cobra.Command) (node.Config, network.Network, error)
 	consensusCfg := consensus.NewConfig(
 		filepath.Join(dataDir, consensus.DataDirName),
 		TendermintRpcListenPort,
-		TendermintProxyListenPort,
+		TendermintP2PListenPort,
 		TendermintProxyAppName,
 		false,
 	)

--- a/cmd/lightchain/run.go
+++ b/cmd/lightchain/run.go
@@ -23,6 +23,7 @@ const (
 	TendermintRpcListenPort   = uint(26657)
 	TendermintProxyListenPort = uint(26658)
 	TendermintProxyProtocol   = "socket"
+	TendermintProxyAppName    = "lightchain"
 )
 
 var (
@@ -45,6 +46,11 @@ var (
 	ConsensusProxyProtocolFlag = cli.StringFlag{
 		Name:  "abci_protocol",
 		Value: TendermintProxyProtocol,
+		Usage: "socket | grpc",
+	}
+	ConsensusProxyAppNameFlag = cli.StringFlag{
+		Name:  "abci_name",
+		Value: TendermintProxyAppName,
 		Usage: "socket | grpc",
 	}
 	PrometheusFlag = cli.BoolFlag{
@@ -73,8 +79,7 @@ func runCmd() *cobra.Command {
 			traceLogFilePath, _ := cmd.Flags().GetString(TraceLogFlag.Name)
 			rpcListenPort, _ := cmd.Flags().GetUint(ConsensusRpcListenPortFlag.GetName())
 			p2pListenPort, _ := cmd.Flags().GetUint(ConsensusP2PListenPortFlag.GetName())
-			proxyListenPort, _ := cmd.Flags().GetUint(ConsensusProxyListenPortFlag.GetName())
-			proxyProtocol, _ := cmd.Flags().GetString(ConsensusProxyProtocolFlag.GetName())
+			proxyAppName, _ := cmd.Flags().GetString(ConsensusProxyAppNameFlag.GetName())
 			enablePrometheus, _ := cmd.Flags().GetBool(PrometheusFlag.GetName())
 			databaseDataDir := filepath.Join(dataDir, database.DataDirPath)
 
@@ -82,8 +87,7 @@ func runCmd() *cobra.Command {
 				filepath.Join(dataDir, consensus.DataDirName),
 				rpcListenPort,
 				p2pListenPort,
-				proxyListenPort,
-				proxyProtocol,
+				proxyAppName,
 				enablePrometheus,
 			)
 

--- a/cmd/lightchain/run.go
+++ b/cmd/lightchain/run.go
@@ -21,8 +21,6 @@ import (
 const (
 	TendermintP2PListenPort   = uint(26656)
 	TendermintRpcListenPort   = uint(26657)
-	TendermintProxyListenPort = uint(26658)
-	TendermintProxyProtocol   = "socket"
 	TendermintProxyAppName    = "lightchain"
 )
 
@@ -36,17 +34,6 @@ var (
 		Name:  "tmt_p2p_port",
 		Value: TendermintP2PListenPort,
 		Usage: "Tendermint port used to achieve exchange messages across nodes",
-	}
-	ConsensusProxyListenPortFlag = cli.UintFlag{
-		Name:  "tmt_proxy_port",
-		Value: TendermintProxyListenPort,
-		Usage: "Lightchain RPC port used to receive incoming messages from Tendermint",
-	}
-	// ABCIProtocolFlag defines whether GRPC or SOCKET should be used for the ABCI connections
-	ConsensusProxyProtocolFlag = cli.StringFlag{
-		Name:  "abci_protocol",
-		Value: TendermintProxyProtocol,
-		Usage: "socket | grpc",
 	}
 	ConsensusProxyAppNameFlag = cli.StringFlag{
 		Name:  "abci_name",
@@ -149,6 +136,4 @@ func addRunCmdFlags(cmd *cobra.Command) {
 func addConsensusFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint(ConsensusRpcListenPortFlag.GetName(), ConsensusRpcListenPortFlag.Value, ConsensusRpcListenPortFlag.Usage)
 	cmd.Flags().Uint(ConsensusP2PListenPortFlag.GetName(), ConsensusP2PListenPortFlag.Value, ConsensusP2PListenPortFlag.Usage)
-	cmd.Flags().Uint(ConsensusProxyListenPortFlag.GetName(), ConsensusProxyListenPortFlag.Value, ConsensusProxyListenPortFlag.Usage)
-	cmd.Flags().String(ConsensusProxyProtocolFlag.GetName(), ConsensusProxyProtocolFlag.Value, ConsensusProxyProtocolFlag.Usage)
 }

--- a/consensus/abci.go
+++ b/consensus/abci.go
@@ -70,6 +70,11 @@ func NewTendermintABCI(db *database.Database, ethRPCClient *rpc.Client, metrics 
 		metrics:           metrics,
 	}
 
+	err = abci.ResetBlockState()
+	if err != nil {
+		return nil, err
+	}
+
 	return abci, nil
 }
 

--- a/consensus/config.go
+++ b/consensus/config.go
@@ -18,19 +18,17 @@ const DataDirName = "consensus"
 //
 // - rpcListenPort 26657
 // - p2pListenPort 26656
-// - ProxyListenPort 26658
-//
+// - proxyAppName lightchain
 type Config struct {
-	dataDir         string
-	tendermintCfg   *config.Config
-	rpcListenPort   uint
-	p2pListenPort   uint
-	proxyListenPort uint
-	proxyProtocol   string
-	metrics         bool
+	dataDir       string
+	tendermintCfg *config.Config
+	rpcListenPort uint
+	p2pListenPort uint
+	proxyAppName  string
+	metrics       bool
 }
 
-func NewConfig(dataDir string, rpcListenPort uint, p2pListenPort uint, proxyListenPort uint, proxyProtocol string, metrics bool) Config {
+func NewConfig(dataDir string, rpcListenPort uint, p2pListenPort uint, proxyAppName string, metrics bool) Config {
 	tendermintCfg := config.DefaultConfig()
 
 	applyTendermintConfig(filepath.Join(dataDir, "config"), tendermintCfg)
@@ -38,15 +36,14 @@ func NewConfig(dataDir string, rpcListenPort uint, p2pListenPort uint, proxyList
 	tendermintCfg.SetRoot(dataDir)
 	tendermintCfg.RPC.ListenAddress = fmt.Sprintf("tcp://0.0.0.0:%d", rpcListenPort)
 	tendermintCfg.P2P.ListenAddress = fmt.Sprintf("tcp://0.0.0.0:%d", p2pListenPort)
-	tendermintCfg.ProxyApp = "lightchain"
+	tendermintCfg.ProxyApp = proxyAppName
 
 	return Config{
 		dataDir,
 		tendermintCfg,
 		rpcListenPort,
 		p2pListenPort,
-		proxyListenPort,
-		proxyProtocol,
+		proxyAppName,
 		metrics,
 	}
 }

--- a/consensus/config.go
+++ b/consensus/config.go
@@ -38,7 +38,7 @@ func NewConfig(dataDir string, rpcListenPort uint, p2pListenPort uint, proxyList
 	tendermintCfg.SetRoot(dataDir)
 	tendermintCfg.RPC.ListenAddress = fmt.Sprintf("tcp://0.0.0.0:%d", rpcListenPort)
 	tendermintCfg.P2P.ListenAddress = fmt.Sprintf("tcp://0.0.0.0:%d", p2pListenPort)
-	tendermintCfg.ProxyApp = fmt.Sprintf("tcp://127.0.0.1:%d", proxyListenPort)
+	tendermintCfg.ProxyApp = "lightchain"
 
 	return Config{
 		dataDir,


### PR DESCRIPTION
Let's test this carefully.