### PR TITLE
#137 Moving tracer.log file into local node datadir

### DIFF
--- a/cmd/lightchain/init.go
+++ b/cmd/lightchain/init.go
@@ -139,12 +139,7 @@ func newNodeCfgFromCmd(cmd *cobra.Command) (node.Config, network.Network, error)
 	)
 
 	tracerCfg := tracer.NewConfig(shouldTrace, path.Join(dataDir, "tracer.log"))
-	if shouldTrace {
-		logger.Info("|--------")
-		logger.Info("| Danger: Tracing enabled is not recommended in production!")
-		logger.Info(fmt.Sprintf("| Tracing output is configured to be persisted at %v", tracerCfg.LogFilePath))
-		logger.Info("|--------")
-	}
+	tracerCfg.PrintWarning(logger);
 
 	return node.NewConfig(dataDir, consensusCfg, dbCfg, prometheusCfg, tracerCfg), ntw, nil
 }

--- a/cmd/lightchain/main.go
+++ b/cmd/lightchain/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"path"
 	"github.com/lightstreams-network/lightchain/log"
-	"path/filepath"
 	"runtime/debug"
 
 	ethLog "github.com/ethereum/go-ethereum/log"
@@ -35,11 +34,6 @@ var (
 	TraceFlag = cli.BoolFlag{
 		Name:  "trace",
 		Usage: "Whenever to be asserting and reporting blockchain state in real-time (testing, debugging purposes)",
-	}
-
-	TraceLogFlag = cli.BoolFlag{
-		Name:  "tracelog",
-		Usage: "The filepath to a log file where all tracing output will be persisted",
 	}
 )
 
@@ -85,7 +79,6 @@ func addDefaultFlags(cmd *cobra.Command) {
 	cmd.Flags().String(LogLvlFlag.Name, LogLvlFlag.Value, LogLvlFlag.Usage)
 
 	cmd.Flags().Bool(TraceFlag.Name, false, TraceFlag.Usage)
-	cmd.Flags().String(TraceLogFlag.Name, filepath.Join(os.TempDir(), "tracer.log"), TraceLogFlag.Usage)
 }
 
 func incorrectUsageErr() error {

--- a/cmd/lightchain/run.go
+++ b/cmd/lightchain/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tendermint/tendermint/libs/common"
 	"github.com/lightstreams-network/lightchain/prometheus"
 	"github.com/lightstreams-network/lightchain/tracer"
+	"path"
 )
 
 const (
@@ -70,7 +71,6 @@ func runCmd() *cobra.Command {
 
 			dataDir, _ := cmd.Flags().GetString(DataDirFlag.GetName())
 			shouldTrace, _ := cmd.Flags().GetBool(TraceFlag.Name)
-			traceLogFilePath, _ := cmd.Flags().GetString(TraceLogFlag.Name)
 			rpcListenPort, _ := cmd.Flags().GetUint(ConsensusRpcListenPortFlag.GetName())
 			p2pListenPort, _ := cmd.Flags().GetUint(ConsensusP2PListenPortFlag.GetName())
 			proxyListenPort, _ := cmd.Flags().GetUint(ConsensusProxyListenPortFlag.GetName())
@@ -102,7 +102,14 @@ func runCmd() *cobra.Command {
 				dbCfg.GethIpcPath(),
 			)
 
-			tracerCfg := tracer.NewConfig(shouldTrace, traceLogFilePath)
+			tracerCfg := tracer.NewConfig(shouldTrace, path.Join(dataDir, "tracer.log"))
+			if shouldTrace {
+				logger.Info("|--------")
+				logger.Info("| Danger: Tracing enabled is not recommended in production!")
+				logger.Info(fmt.Sprintf("| Tracing output is configured to be persisted at %v", tracerCfg.LogFilePath))
+				logger.Info("|--------")
+			}
+
 			nodeCfg := node.NewConfig(dataDir, consensusCfg, dbCfg, prometheusCfg, tracerCfg)
 
 			n, err := node.NewNode(&nodeCfg)

--- a/cmd/lightchain/run.go
+++ b/cmd/lightchain/run.go
@@ -103,12 +103,7 @@ func runCmd() *cobra.Command {
 			)
 
 			tracerCfg := tracer.NewConfig(shouldTrace, path.Join(dataDir, "tracer.log"))
-			if shouldTrace {
-				logger.Info("|--------")
-				logger.Info("| Danger: Tracing enabled is not recommended in production!")
-				logger.Info(fmt.Sprintf("| Tracing output is configured to be persisted at %v", tracerCfg.LogFilePath))
-				logger.Info("|--------")
-			}
+			tracerCfg.PrintWarning(logger);
 
 			nodeCfg := node.NewConfig(dataDir, consensusCfg, dbCfg, prometheusCfg, tracerCfg)
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -40,7 +40,7 @@ DATA_DIR="${DATA_DIR}/${NETWORK}"
 INIT_ARGS="--datadir=${DATA_DIR} --${NETWORK}"
 
 RUN_ARGS="--datadir=${DATA_DIR}"
-RUN_ARGS="${RUN_ARGS} --rpc --rpcaddr 0.0.0.0 --rpcport 8545 --rpcapi eth,net,web3,personal,admin,debug --rpc"
+RUN_ARGS="${RUN_ARGS} --rpc --rpcaddr 0.0.0.0 --rpcport 8545 --rpcapi eth,net,web3,personal,admin,debug"
 RUN_ARGS="${RUN_ARGS} --ws --wsport 8556 --wsaddr 0.0.0.0 --wsapi eth,net,web3,personal,admin,debug --wsorigins=*"
 RUN_ARGS="${RUN_ARGS} --tmt_rpc_port=26657 --tmt_proxy_port=26658 --tmt_p2p_port=26656"
 RUN_ARGS="${RUN_ARGS} --prometheus"

--- a/tracer/config.go
+++ b/tracer/config.go
@@ -1,5 +1,10 @@
 package tracer
 
+import (
+	tmtLog "github.com/tendermint/tendermint/libs/log"
+	"fmt"
+)
+
 type Config struct {
 	ShouldTrace bool
 	LogFilePath string
@@ -7,4 +12,11 @@ type Config struct {
 
 func NewConfig(shouldTrace bool, logFilePath string) Config {
 	return Config{shouldTrace, logFilePath}
+}
+
+func (c Config) PrintWarning(logger tmtLog.Logger) {
+	logger.Info("|--------")
+	logger.Info("| Danger: Tracing enabled is not recommended in production!")
+	logger.Info(fmt.Sprintf("| Tracing output is configured to be persisted at %v", c.LogFilePath))
+	logger.Info("|--------")
 }


### PR DESCRIPTION
### Changes
- Removed optional path for `tracer.log` in favor of a fixed one `${DATADIR}/tracer.log`

### How to test
` Run `lightchain init --trace` and check file is written correctly
` Run `lightchain simulate --trace` and check file is written correctly 