### PR TITLE
#201 Enables Constantinople at block 492834 on Mainnet.

### DIFF
--- a/cmd/lightchain/version.go
+++ b/cmd/lightchain/version.go
@@ -6,9 +6,9 @@ import (
 )
 
 const Major = "1"
-const Minor = "3"
-const Fix = "2"
-const Verbal = "Fast && Safe"
+const Minor = "4"
+const Fix = "0"
+const Verbal = "Constantinople"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/network/mainnet/database/genesis.go
+++ b/network/mainnet/database/genesis.go
@@ -10,7 +10,9 @@ const Genesis = `
         "eip150Block": 0,
         "eip155Block": 0,
         "eip158Block": 0,
-        "ByzantiumBlock": 0
+        "ByzantiumBlock": 0,
+        "ConstantinopleBlock": 492834,
+        "PetersburgBlock": 492834
     },
     "nonce": "1",
     "difficulty": "1024",


### PR DESCRIPTION
After running Lightchain, validate the fork settings:

<img width="1440" alt="Screen Shot 2020-03-02 at 12 01 15" src="https://user-images.githubusercontent.com/3595242/75671140-5b8fb200-5c7e-11ea-8570-44895e704d95.png">
